### PR TITLE
GO: add logic to go build step that finds all the subdirectories that are needed to build

### DIFF
--- a/src/go/commands/build.yaml
+++ b/src/go/commands/build.yaml
@@ -1,22 +1,36 @@
-description: "Go build package"
+description: "Parse go code structure for packages to build."
 parameters:
-  package_name:
-    description: the name to package the build as (used with -o ./bin/__)
-    type: string
-  import_path:
-    description: path to the code to build (generic would be ./...)
-    type: string
   cgo_value:
     default: "0"
     type: string
+  os_value:
+    default: "linux"
+    type: string
 steps:
   - run:
+      name: '[go] Build'
       command: |
         ver=$(git describe --tags --always --dirty)
         ld_flags="-X 'main.version=$ver'"
-        CGO_ENABLED=<<parameters.cgo_value>> GOOS=linux go build -ldflags "$ld_flags" -a -o ./bin/<<parameters.package_name>> <<parameters.import_path>>
-      name: '[go] Build'
+
+        go list -f {{.ImportPath}}%{{.Name}} ./... | while IFS= read -r import_string ; do
+          if [[ $import_string != *"/cmd/"* ]]; then
+            continue
+          fi
+
+          arr_parts=(${import_string//%/ })
+          if [[ ${arr_parts[1],,} != "main" ]]; then
+            echo "The expected package is 'main'. Not building: $import_string"
+            continue
+          fi
+          importPath=${arr_parts[0]}
+          name="${importPath##*/}"
+
+          echo "Building: $name..."
+          CGO_ENABLED=<<parameters.cgo_value>> GOOS=<<parameters.os_value>> go build -ldflags "$ld_flags" -a -o "./bin/$name" "$importPath"
+        done
+  - run: ls -alh ./bin
   - persist_to_workspace:
       root: ./
       paths:
-        - bin/<<parameters.package_name>>
+        - bin/*

--- a/src/go/examples/build_and_test.yaml
+++ b/src/go/examples/build_and_test.yaml
@@ -18,21 +18,6 @@ usage:
         GOPRIVATE: "github.com/your-org/*"
         CC_TEST_REPORTER_ID: 123ABC # the Code Climate token for this repo
 
-  jobs:
-    # for compiling multiple binaries within one repo
-    compile_code:
-      executor: golang-executor
-      steps:
-        - checkout
-        - ta-go/load-cache
-        - ta-go/build:
-            package_name: package
-            import_path: github.com/your-org/repo-name/path-to/package
-        - ta-go/build:
-            package_name: alternate
-            import_path: github.com/your-org/repo-name/path-to/alternate
-        - ta-go/save-cache
-
   workflows:
     build_and_test:
       jobs:
@@ -43,7 +28,8 @@ usage:
         - ta-go/test_and_coverage:
             exec: golang-executor
             additional_flags: "--prefix=v3"
-        - compile_code:
+        - ta-go/build:
+            exec: golang-executor
             requires:
               - ta-go/checks
               - ta-go/protobuf_eval

--- a/src/go/jobs/build.yaml
+++ b/src/go/jobs/build.yaml
@@ -1,0 +1,18 @@
+description: |
+  Parse go code structure for packages to build.
+  Looks for /cmd subdirectory, and builds the main packages within that subdirectory.
+  For example, the expected import path should be:
+    github.com/my-org/repo-name/v1/cmd/packageName
+
+parameters:
+  exec:
+    description: Executor to use for this job
+    type: executor
+    default: go_executor
+executor: << parameters.exec >>
+
+steps:
+  - checkout
+  - load-cache
+  - build
+  - save-cache


### PR DESCRIPTION
**What this PR does / why we need it**:
adds opinionated way to manage `go build` in a single job

