### PR TITLE
Add protoc gen go dep

### DIFF
--- a/src/code-climate/commands/format_coverage.yaml
+++ b/src/code-climate/commands/format_coverage.yaml
@@ -26,5 +26,5 @@ parameters:
     type: string
 steps:
   - run:
-      command: cc-test-reporter format-coverage "<<parameters.additional_flags>>" "<<parameters.coverage_file>>" --input-type <<parameters.input_type>> --output "<<parameters.output>>"
+      command: cc-test-reporter format-coverage <<# parameters.additional_flags>> "<<parameters.additional_flags>>" <</ parameters.additional_flags>> "<<parameters.coverage_file>>" --input-type <<parameters.input_type>> --output "<<parameters.output>>"
       name: Formatting coverage report

--- a/src/go/commands/make-gen.yaml
+++ b/src/go/commands/make-gen.yaml
@@ -1,5 +1,6 @@
 description: Execute make gen in order to rebuild the generated protobuf files locally
 steps:
   - run: GO111MODULE=off go get -u github.com/vektra/mockery/cmd/mockery
+  - run: GO111MODULE=off go get -u github.com/golang/protobuf/protoc-gen-go
   - run: GO111MODULE=off go get -u golang.org/x/tools/cmd/goimports
   - run: make gen


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new dependency, the github.com/golang/protobuf/protoc-gen-go tool, in order to correctly generate Protobuf. 

This PR also includes a change in the way the code climate reporting tool uses parameters passed in so when empty it doesn't error.
