### PR TITLE
escape name

### DIFF
--- a/src/docker/commands/get_change_name.yaml
+++ b/src/docker/commands/get_change_name.yaml
@@ -3,12 +3,10 @@ steps:
   - run: |
           if [ ! -z "$CIRCLE_TAG" ];
           then
-            CIRCLE_NAME=$CIRCLE_TAG
+            echo 'export CHANGE_NAME="$(echo "$CIRCLE_TAG" | sed -r 's/[\/=_#]+/-/g')"' >> $BASH_ENV
           elif [ ! -z "$CIRCLE_BRANCH" ];
           then
-            CIRCLE_NAME=$CIRCLE_BRANCH
+            echo 'export CHANGE_NAME="$(echo "$CIRCLE_BRANCH" | sed -r 's/[\/=_#]+/-/g')"' >> $BASH_ENV
           fi
-          CIRCLE_NAME=$(echo "$CIRCLE_NAME" | sed -r 's/[\/=_#]+/-/g')
-          echo 'export CHANGE_NAME=$CIRCLE_NAME' >> $BASH_ENV
           source $BASH_ENV
           echo $CHANGE_NAME

--- a/src/docker/commands/get_change_name.yaml
+++ b/src/docker/commands/get_change_name.yaml
@@ -3,10 +3,12 @@ steps:
   - run: |
           if [ ! -z "$CIRCLE_TAG" ];
           then
-            echo 'export CHANGE_NAME=$CIRCLE_TAG' >> $BASH_ENV
+            CIRCLE_NAME=$CIRCLE_TAG
           elif [ ! -z "$CIRCLE_BRANCH" ];
           then
-            echo 'export CHANGE_NAME=$CIRCLE_BRANCH' >> $BASH_ENV
+            CIRCLE_NAME=$CIRCLE_BRANCH
           fi
+          CIRCLE_NAME=$(echo "$CIRCLE_NAME" | sed -r 's/[\/=_#]+/-/g')
+          echo 'export CHANGE_NAME=$CIRCLE_NAME' >> $BASH_ENV
           source $BASH_ENV
           echo $CHANGE_NAME


### PR DESCRIPTION


**What this PR does / why we need it**:
It fixes the issue with docker push command failing in case branch name contains `/` and a couple of other special characters
