### PR TITLE
index helm repo after adding new chart

### DIFF
--- a/src/helm/@orb.yml
+++ b/src/helm/@orb.yml
@@ -1,4 +1,4 @@
-version: 2.2
+version: 2.1
 
 description: |
   CircleCI Orb for helm CI. Provides helm package and pushing charts to github helm repo, amongst other things...

--- a/src/helm/@orb.yml
+++ b/src/helm/@orb.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2.2
 
 description: |
   CircleCI Orb for helm CI. Provides helm package and pushing charts to github helm repo, amongst other things...

--- a/src/helm/commands/push.yaml
+++ b/src/helm/commands/push.yaml
@@ -30,8 +30,10 @@ steps:
             git reset --hard origin/master
             if ["$CIRCLE_BRANCH" == "master" ]; then
               cp ../<<parameters.chart_package_path>>/* stable/
+              cd stable;helm repo index .
             else
               cp ../<<parameters.chart_package_path>>/* incubator/
+              cd incubator;helm repo index .
             fi
             git add .
             git commit -m "updating helm charts: $(ls ../<<parameters.chart_package_path>>)"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Make sure helm repo will be reindexed with the new added new chart
**Special notes for your reviewer**:

**If applicable**:
- [X] All new Jobs, Commands, Executors, Parameters have descriptions
- [X] If PR adds a new feature, Examples have been added
- [X] README has been updated, if necessary
