### PR TITLE
DEPLOY: add the server name env var for the default

### DIFF
--- a/src/deploy/jobs/jenkins_build_with_parameters.yaml
+++ b/src/deploy/jobs/jenkins_build_with_parameters.yaml
@@ -16,7 +16,7 @@ parameters:
   server_url:
     description: "Jenkins endpoint"
     type: env_var_name
-    default:
+    default: JENKINS_SERVER_URL
   team_folder:
     type: string
     description: Team name where the deploy jobs in Jenkins sit


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes not using the default env var
