### PR TITLE
DOCKER: increase the wait threshold to allow for builds to complete before retagging image

### DIFF
--- a/src/docker/jobs/docker_git_tag.yaml
+++ b/src/docker/jobs/docker_git_tag.yaml
@@ -5,11 +5,11 @@ parameters:
   retry_count:
     description: Amount of attempts to make while waiting for the image to exist in the registry
     type: integer
-    default: 5
+    default: 8
   wait_period:
     description: Seconds to wait between retries
     type: integer
-    default: 60
+    default: 90
   image-name:
     description: Name of image to re-tag
     type: string


### PR DESCRIPTION
**What this PR does / why we need it**:
The original threshold wasn't enough for most use cases. It's still an optional param that can be increased on longer running jobs.
