### PR TITLE
Fix helm package for master branch packaging 

### DIFF
--- a/src/helm/commands/package.yaml
+++ b/src/helm/commands/package.yaml
@@ -40,16 +40,21 @@ steps:
             helm dependency build "$chart"
 
             # set the version different for incubator
-            if [ "$CIRCLE_BRANCH" == "master" ]; then
-              helm package "$chart" --destination <<parameters.chart_package_path>>
-            else
-              ver=$(helm inspect chart "$chart" | grep version | cut -d' ' -f2)
-              [[ -z $CIRCLE_TAG ]] && BRANCH="$CIRCLE_BRANCH" || BRANCH="$CIRCLE_TAG"
-              echo "packaging $chart with version: ${ver}-${BRANCH}"
-              helm package "$chart" -u --version "${ver}-${BRANCH}" --destination .cr-release-packages
-            fi
+            ver=$(helm inspect chart "$chart" | grep version | cut -d' ' -f2)
+            [[ -z $CIRCLE_TAG ]] && BRANCH="$CIRCLE_BRANCH" || BRANCH="$CIRCLE_TAG"
+            echo "packaging $chart with version: ${ver}-${BRANCH}"
+            helm package "$chart" -u --version "${ver}-${BRANCH}" --destination .cr-release-packages
 
             echo "'$chart' packaged"
             echo "-----"
         done
+        
+        if [ "$CIRCLE_BRANCH" == "master" ]; then
+          git diff HEAD^ HEAD | grep "helm/.*/Chart.yaml$" | sed -n '3p;6p;9p' | awk '{print $2}' | sed 's/\/Chart.yaml$//' | sed 's/\// /g'
+          echo "Packaging chart: '$chart'..."
+          helm dependency build "$chart"
+          helm package "$chart" --destination <<parameters.chart_package_path>>
+          echo "'$chart' packaged"
+          echo "-----"
+        fi
       name: "[helm] Package"

--- a/src/helm/commands/package.yaml
+++ b/src/helm/commands/package.yaml
@@ -36,10 +36,14 @@ steps:
             helm dependency build "$chart"
 
             # set the version different for incubator
-            ver=$(helm inspect chart "$chart" | grep version | cut -d' ' -f2)
-            [[ -z $CIRCLE_TAG ]] && BRANCH="$CIRCLE_BRANCH" || BRANCH="$CIRCLE_TAG"
-            echo "packaging $chart with version: ${ver}-${BRANCH}"
-            helm package "$chart" -u --version "${ver}-${BRANCH}" --destination .cr-release-packages
+            if [ "$CIRCLE_BRANCH" == "master" ]; then
+              helm package "$chart" --destination <<parameters.chart_package_path>>
+            else
+              ver=$(helm inspect chart "$chart" | grep version | cut -d' ' -f2)
+              [[ -z $CIRCLE_TAG ]] && BRANCH="$CIRCLE_BRANCH" || BRANCH="$CIRCLE_TAG"
+              echo "packaging $chart with version: ${ver}-${BRANCH}"
+              helm package "$chart" -u --version "${ver}-${BRANCH}" --destination .cr-release-packages
+            fi
 
             echo "'$chart' packaged"
             echo "-----"

--- a/src/helm/commands/package.yaml
+++ b/src/helm/commands/package.yaml
@@ -11,6 +11,13 @@ parameters:
         validate-maintainers: false
     type: string
     default: ".circleci/helmTestConfig.yaml"
+  chart_dir_override:
+    description: |
+      Due to 'ct list-changed' not working on master (see https://github.com/helm/chart-testing/pull/159)
+      Need get changed charts through git command.
+      Defaulting to searching in 'helm' dir to look for changes.
+    type: string
+    default: "helm"
   chart_package_path:
     description: The path where packaged charts will be saved (defaults to a local, relative path)
     type: string
@@ -19,23 +26,12 @@ steps:
   - run:
       shell: /bin/sh
       command: |
-        helm init --client-only  || true  # this step is required for helm v2
-        helm version -c
-        if [ "$CT_CHART_REPOS" ]; then
-            for i in $(echo $CT_CHART_REPOS | tr "," " ");
-            do
-                repo_name=$(echo "$i" | cut -d'=' -f1)
-                repo_url=$(echo "$i" | cut -d'=' -f2)
-                helm repo add $repo_name $repo_url
-            done
-        fi
-        rm -rf <<parameters.chart_package_path>>; mkdir <<parameters.chart_package_path>>
-        ct list-changed --config <<parameters.chart_test_config>> | while IFS= read -r chart ; do
-            chart=$(echo $chart | sed 's/.*Skipping...//g')
-            if [ "$chart" == "" ]; then
-              continue
-            fi
-
+        # Package up the chart to <<parameters.chart_package_path>>.
+        #
+        #  $ package_chart chart/path
+        #
+        function package_chart {
+            chart=$1
             echo "Packaging chart: '$chart'..."
             helm dependency build "$chart"
 
@@ -47,14 +43,36 @@ steps:
 
             echo "'$chart' packaged"
             echo "-----"
-        done
-        
+        }
+
+        helm init --client-only  || true  # this step is required for helm v2
+        helm version -c
+        if [ "$CT_CHART_REPOS" ]; then
+            for i in $(echo $CT_CHART_REPOS | tr "," " ");
+            do
+                repo_name=$(echo "$i" | cut -d'=' -f1)
+                repo_url=$(echo "$i" | cut -d'=' -f2)
+                helm repo add $repo_name $repo_url
+            done
+        fi
+        rm -rf <<parameters.chart_package_path>>; mkdir <<parameters.chart_package_path>>
+
+        # 'ct list-changed' doesn't work on master branch
+        #   see https://github.com/helm/chart-testing/pull/159
         if [ "$CIRCLE_BRANCH" == "master" ]; then
-          git diff HEAD^ HEAD | grep "helm/.*/Chart.yaml$" | sed -n '3p;6p;9p' | awk '{print $2}' | sed 's/\/Chart.yaml$//' | sed 's/\// /g'
-          echo "Packaging chart: '$chart'..."
-          helm dependency build "$chart"
-          helm package "$chart" --destination <<parameters.chart_package_path>>
-          echo "'$chart' packaged"
-          echo "-----"
+            git diff --name-only $(git merge-base HEAD^ HEAD) -- <<parameters.chart_dir_override>>  | while IFS= read -r file ; do
+                if echo "$file" | grep -q "/Chart.yaml"; then
+                    chart=$(echo "$file" | sed 's/\/Chart.yaml$//')
+                    package_chart $chart
+                fi
+            done
+        else
+            ct list-changed --config <<parameters.chart_test_config>> | while IFS= read -r chart ; do
+                chart=$(echo $chart | sed 's/.*Skipping...//g')
+                if [ "$chart" == "" ]; then
+                  continue
+                fi
+                package_chart $chart
+            done
         fi
       name: "[helm] Package"

--- a/src/helm/commands/push.yaml
+++ b/src/helm/commands/push.yaml
@@ -25,20 +25,20 @@ steps:
             cd .helmPath
             git config user.email "$GIT_EMAIL"
             git config user.name "$GIT_USERNAME"
+            files_changed=$(ls ../<<parameters.chart_package_path>>)
 
             git fetch
             git reset --hard origin/master
             if [ "$CIRCLE_BRANCH" == "master" ]; then
               cp ../<<parameters.chart_package_path>>/* stable/
-              cd stable;helm repo index .
+              cd stable
+              helm repo index .
             else
               cp ../<<parameters.chart_package_path>>/* incubator/
-              cd incubator;helm repo index .
+              cd incubator
+              helm repo index .
             fi
-            files_changed=$(ls ../<<parameters.chart_package_path>>)
-            pwd
             echo "---$files_changed--"
-            ls -al ../
             git add .
             git commit -m "updating helm charts: $files_changed"
             git push --set-upstream origin master

--- a/src/helm/commands/push.yaml
+++ b/src/helm/commands/push.yaml
@@ -28,7 +28,7 @@ steps:
 
             git fetch
             git reset --hard origin/master
-            if ["$CIRCLE_BRANCH" == "master" ]; then
+            if [ "$CIRCLE_BRANCH" == "master" ]; then
               cp ../<<parameters.chart_package_path>>/* stable/
               cd stable;helm repo index .
             else

--- a/src/helm/commands/push.yaml
+++ b/src/helm/commands/push.yaml
@@ -35,8 +35,11 @@ steps:
               cp ../<<parameters.chart_package_path>>/* incubator/
               cd incubator;helm repo index .
             fi
+            $files_changed=$(ls ../<<parameters.chart_package_path>>)
+            pwd
+            echo "---$files_changed--"
             git add .
-            git commit -m "updating helm charts: $(ls ../<<parameters.chart_package_path>>)"
+            git commit -m "updating helm charts: $files_changed"
             git push --set-upstream origin master
         }
 

--- a/src/helm/commands/push.yaml
+++ b/src/helm/commands/push.yaml
@@ -35,9 +35,10 @@ steps:
               cp ../<<parameters.chart_package_path>>/* incubator/
               cd incubator;helm repo index .
             fi
-            $files_changed=$(ls ../<<parameters.chart_package_path>>)
+            files_changed=$(ls ../<<parameters.chart_package_path>>)
             pwd
             echo "---$files_changed--"
+            ls -al ../
             git add .
             git commit -m "updating helm charts: $files_changed"
             git push --set-upstream origin master

--- a/src/helm/jobs/package_and_push.yaml
+++ b/src/helm/jobs/package_and_push.yaml
@@ -4,6 +4,21 @@ parameters:
   chart_git_repo:
     description: The github repo that keeps packaged charts
     type: string
+  chart_test_config:
+    description: |
+      Path to local config file with settings to be used by Chart Tester
+      For example:
+        helm-extra-args: --timeout 600
+        validate-maintainers: false
+    type: string
+    default: ".circleci/helmTestConfig.yaml"
+  chart_dir_override:
+    description: |
+      Due to 'ct list-changed' not working on master (see https://github.com/helm/chart-testing/pull/159)
+      Need get changed charts through git command.
+      Defaulting to searching in 'helm' dir to look for changes.
+    type: string
+    default: "helm"
   exec:
     description: The name of custom executor to use
     type: executor
@@ -11,6 +26,8 @@ parameters:
 executor: << parameters.exec >>
 steps:
   - checkout
-  - package
+  - package:
+      chart_test_config: <<parameters.chart_test_config>>
+      chart_dir_override: <<parameters.chart_dir_override>>
   - push:
       chart_git_repo: <<parameters.chart_git_repo>>


### PR DESCRIPTION
**What this PR does / why we need it**:
The chart testing tool doesn't check for changes when "target branch" _(ie: master)_ is the same as the current branch. This means that when a PR is merged into master, any chart changes are not pushed to stable chart repo. 

**Special notes for your reviewer**:
There's an upstream PR that could make this cleaner, but for now there's two "tracks" for master vs feature branch. 

**If applicable**:
- [x] All new Jobs, Commands, Executors, Parameters have descriptions
