### PR TITLE
HELM: packaging was failing, but build was successful

### DIFF
--- a/src/helm/commands/package.yaml
+++ b/src/helm/commands/package.yaml
@@ -26,6 +26,7 @@ steps:
   - run:
       shell: /bin/sh
       command: |
+        set -e
         # Package up the chart to <<parameters.chart_package_path>>.
         #
         #  $ package_chart chart/path
@@ -41,8 +42,9 @@ steps:
             else
               ver=$(helm inspect chart "$chart" | grep version | cut -d' ' -f2)
               [[ -z $CIRCLE_TAG ]] && BRANCH="$CIRCLE_BRANCH" || BRANCH="$CIRCLE_TAG"
-              echo "packaging $chart with version: ${ver}-${BRANCH}"
-              helm package "$chart" -u --version "${ver}-${BRANCH}" --destination .cr-release-packages
+              VERSION="$(echo "${ver}-${BRANCH}" | sed -r 's/[\/=_#]+/-/g')"
+              echo "packaging $chart with version: ${VERSION}"
+              helm package "$chart" -u --version "${VERSION}" --destination .cr-release-packages
             fi
 
             echo "'$chart' packaged"
@@ -72,7 +74,7 @@ steps:
             done
         else
             ct list-changed --config <<parameters.chart_test_config>> | while IFS= read -r chart ; do
-                chart=$(echo $chart | sed 's/.*Skipping...//g')
+                chart=$(echo $chart | sed 's/.*Skipping...//g' | sed 's/Version increment checking disabled.//g')
                 if [ "$chart" == "" ]; then
                   continue
                 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
adding `set -e` was important, because the package step was failing, but the CircleCI build was successful. See https://support.circleci.com/hc/en-us/articles/115015733328-Tests-fail-but-job-finishes-successfully

**Special notes for your reviewer**:
The reason for the failure was twofold:
1. The `version-branchname` was an invalid semantic version due to `/` in the version name, so now replacing some special chars
2. the `ct list-changed` was including a debug statement that was triggering packaging of a false chart
