### PR TITLE
protoc version

### DIFF
--- a/src/go/commands/make-gen.yaml
+++ b/src/go/commands/make-gen.yaml
@@ -5,5 +5,11 @@ parameters:
     default: "v1.3.2"
     type: string
 steps:
-  - run: cd ../ && go get -u github.com/vektra/mockery/cmd/mockery golang.org/x/tools/cmd/goimports github.com/golang/protobuf/protoc-gen-go@<<parameters.protoc_version>>
+  - run:
+      name: '[go] install deps'
+      command: |
+        cd ../
+        go get -u github.com/vektra/mockery/cmd/mockery
+        golang.org/x/tools/cmd/goimports
+        github.com/golang/protobuf/protoc-gen-go@<<parameters.protoc_version>>
   - run: make gen

--- a/src/go/commands/make-gen.yaml
+++ b/src/go/commands/make-gen.yaml
@@ -5,7 +5,5 @@ parameters:
     default: "v1.3.2"
     type: string
 steps:
-  - run: GO111MODULE=off go get -u github.com/vektra/mockery/cmd/mockery
-  - run: go get -u github.com/golang/protobuf/protoc-gen-go@<<parameters.protoc_version>>
-  - run: GO111MODULE=off go get -u golang.org/x/tools/cmd/goimports
+  - run: cd ../ && go get -u github.com/vektra/mockery/cmd/mockery golang.org/x/tools/cmd/goimports github.com/golang/protobuf/protoc-gen-go@<<parameters.protoc_version>>
   - run: make gen

--- a/src/go/commands/make-gen.yaml
+++ b/src/go/commands/make-gen.yaml
@@ -6,6 +6,6 @@ parameters:
     type: string
 steps:
   - run: GO111MODULE=off go get -u github.com/vektra/mockery/cmd/mockery
-  - run: GO111MODULE=off go get -u github.com/golang/protobuf/protoc-gen-go@<<parameters.protoc_version>>
+  - run: go get -u github.com/golang/protobuf/protoc-gen-go@<<parameters.protoc_version>>
   - run: GO111MODULE=off go get -u golang.org/x/tools/cmd/goimports
   - run: make gen

--- a/src/go/commands/make-gen.yaml
+++ b/src/go/commands/make-gen.yaml
@@ -1,6 +1,11 @@
 description: Execute make gen in order to rebuild the generated protobuf files locally
+parameters:
+  protoc_version:
+    description: Version of protoc-gen-go to install
+    default: "v1.3.2"
+    type: string
 steps:
   - run: GO111MODULE=off go get -u github.com/vektra/mockery/cmd/mockery
-  - run: GO111MODULE=off go get -u github.com/golang/protobuf/protoc-gen-go
+  - run: GO111MODULE=off go get -u github.com/golang/protobuf/protoc-gen-go@<<parameters.protoc_version>>
   - run: GO111MODULE=off go get -u golang.org/x/tools/cmd/goimports
   - run: make gen

--- a/src/go/jobs/protobuf_eval.yaml
+++ b/src/go/jobs/protobuf_eval.yaml
@@ -8,6 +8,10 @@ parameters:
     description: The version of protobuf tool to install
     type: string
     default: "3.6.1" # 3.11.2 is available...
+  protoc_version:
+    description: Version of protoc-gen-go to install
+    default: "v1.3.2"
+    type: string
 executor: <<parameters.exec>>
 steps:
   - protobuf/install:
@@ -17,6 +21,7 @@ steps:
   - run: sudo chmod -R +r /usr/local/include/google
   - checkout
   - go/load-cache
-  - make-gen
+  - make-gen:
+      protoc_version: <<parameters.protoc_version>>
   - compare
   - go/save-cache


### PR DESCRIPTION
Fixing issue
`cannot use path@version syntax in GOPATH mode`
