### PR TITLE
disable required check for past revision values

### DIFF
--- a/src/gcloud/jobs/copy_file.yaml
+++ b/src/gcloud/jobs/copy_file.yaml
@@ -20,11 +20,13 @@ parameters:
       The sha from the last commit. Available with CircleCI Pipeline Variable:
       https://circleci.com/docs/2.0/pipeline-variables/
     type: string
+    default: ""
   current_revision:
     description: |
       The sha from current commit. Available with CircleCI Pipeline Variable:
       https://circleci.com/docs/2.0/pipeline-variables/
     type: string
+    default: ""
   only_file_change:
     description: Only cp things if the has been a change in the source from previous revision
     type: boolean


### PR DESCRIPTION
**What this PR does / why we need it**:
we got errors in the form of:
```
# Error calling workflow: 'copy_staging'
# Error calling job: 'ta-gcloud/copy_file'
# Unknown variable(s): previous_revision
```
which meant that even though, `only_file_change` was set to `false`, the parameter value was still required, and causing errors

**Special notes for your reviewer**:
It would probably be better to add more conditionals to check if all the values are provided when they're needed, but instead I think the revision check might need a bigger refactor.
