### PR TITLE
SCALA: add a new orb for building scala jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,26 @@ workflows:
             - gcloud-lint
             - gcloud-pack
 
+      # Scala
+      - orb-tools/lint:
+          lint-dir: src/scala
+          name: scala-lint
+      - orb-tools/pack:
+          source-dir: src/scala
+          destination-orb-path: scala.yaml
+          name: scala-pack
+          workspace-path: scala.yaml
+      - orb-tools/publish-dev:
+          name: scala-dev-publish
+          context: orb-publishing
+          orb-name: travelaudience/scala
+          orb-path: workspace/scala.yaml
+          alpha-version-ref: "dev:$CIRCLE_BRANCH"
+          publish-token-variable: CIRCLE_ORB_TOKEN
+          requires:
+            - scala-lint
+            - scala-pack
+
   orb-promotion:
     jobs:
       - pre-orb-promotion-check:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - `travelaudience/go`: [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/travelaudience/go)](https://circleci.com/orbs/registry/orb/travelaudience/go)
 - `travelaudience/helm`: [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/travelaudience/helm)](https://circleci.com/orbs/registry/orb/travelaudience/helm)
 - `travelaudience/gcloud`: [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/travelaudience/gcloud)](https://circleci.com/orbs/registry/orb/travelaudience/gcloud)
+- `travelaudience/scala`: [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/travelaudience/scala)](https://circleci.com/orbs/registry/orb/travelaudience/scala)
 
 Orbs are added to the [registry](https://circleci.com/orbs/registry) through the CircleCI API.
 The build in this repository (`.circleci/config.yml`) uses that API via the CircleCI CLI to take the source of orbs located in the `src` folder, and register them as orbs with CircleCI.

--- a/src/scala/@orb.yml
+++ b/src/scala/@orb.yml
@@ -1,0 +1,8 @@
+version: 2.1
+
+description: |
+  CircleCI Orb for scala CI. Provides static analysis, sbt test, sbt compile, amongst other things...
+  see github page for more info: https://github.com/travelaudience/orbs
+
+orbs:
+  code-climate: travelaudience/code-climate@0.1

--- a/src/scala/commands/compile.yaml
+++ b/src/scala/commands/compile.yaml
@@ -1,0 +1,15 @@
+description: |
+  Compile a "fat" jar for adding to a docker image.
+
+steps:
+  - run:
+      name: '[scala] Assembly'
+      command: |
+        version=$(git describe --tags --always)
+        sbt 'set streaming / assembly / target := new File("target/fat-jar")' 'set ThisBuild / version := "'${version}'"' 'streaming / assembly'
+  - store_artifacts:
+      path: target/fat-jar
+  - persist_to_workspace:
+      root: ./
+      paths:
+        - target/fat-jar/*

--- a/src/scala/commands/test.yaml
+++ b/src/scala/commands/test.yaml
@@ -1,0 +1,44 @@
+description: |
+  Run `sbt test:test` against the repo. Provides an option to upload coverage report to code climate.
+  If using coverage, it's advisable to add `scoverage` to plugins.sbt
+parameters:
+  project_base:
+    description: Where test output gets placed
+    type: string
+    default: common/target
+  with_coverage:
+    description: |
+      Enable the use of code-climate for test coverage analysis
+        requires code-climate CC_TEST_REPORTER_ID env variable to be added to the job
+        the best place for this is in the project in CircleCI UI
+        the code-climate ID is specific to each repo
+    type: boolean
+    default: true
+  path_to_coverage_file:
+    description: Where the test coverage report gets created.
+    type: string
+    default: scala-2.12/coverage-report/cobertura.xml
+steps:
+  - when:
+      condition: << parameters.with_coverage >>
+      steps:
+        - code-climate/install
+        - run: cc-test-reporter before-build
+  - run: sbt test:compile
+  - when:
+      condition: << parameters.with_coverage >>
+      steps:
+        - run: sbt coverage test:test coverageReport
+  - unless:
+      condition: << parameters.with_coverage >>
+      steps:
+        - run: sbt test:test
+  - when:
+      condition: << parameters.with_coverage >>
+      steps:
+        - code-climate/format_coverage:
+            coverage_file: << parameters.project_base >>/<< parameters.path_to_coverage_file >>
+            input_type: cobertura
+        - code-climate/upload_coverage
+  - store_test_results:
+      path: << parameters.project_base >>

--- a/src/scala/examples/check_and_compile.yaml
+++ b/src/scala/examples/check_and_compile.yaml
@@ -1,0 +1,14 @@
+description: |
+  If you are building a jar file that will then be added to a docker image, you can use this orb to run through
+  a common scala workflow. (using scalafmt and scoverage for code coverage analysis)
+usage:
+  version: 2.1
+
+  orbs:
+    ta-scala: travelaudience/scala@x.y.z
+
+  workflows:
+    build_and_test:
+      jobs:
+        - ta-scala/static_check
+        - ta-scala/test_and_compile

--- a/src/scala/examples/only_test.yaml
+++ b/src/scala/examples/only_test.yaml
@@ -1,0 +1,32 @@
+description: |
+  If you don't need to compile a jar file, and you only want to test the code, and you won't be saving the coverage report.
+
+usage:
+  version: 2.1
+
+  orbs:
+    ta-scala: travelaudience/scala@x.y.z
+
+  jobs:
+    test:
+      description: Only test, without coverage
+      executor: ta-scala/scala
+      steps:
+        - checkout
+        - restore_cache:
+            keys:
+              - dependencies-{{ checksum "build.sbt" }}
+        - ta-scala/test:
+            with_coverage: false
+        - save_cache:
+            paths:
+              - ~/.ivy2
+              - ~/.sbt
+              - ~/.m2
+            key: dependencies-{{ checksum "build.sbt" }}
+
+  workflows:
+    only_test:
+      jobs:
+        - ta-scala/static_check
+        - test

--- a/src/scala/executors/scala.yaml
+++ b/src/scala/executors/scala.yaml
@@ -1,0 +1,14 @@
+description: |
+  The docker container to used to test & build Scala projects.
+parameters:
+  version:
+    description: jdk/sbt/scala version to use (docker tag)
+    type: string
+    default: 8u222_1.3.3_2.12.10
+  working_directory:
+    description: directory path for this job
+    type: string
+    default: "~/repo"
+docker:
+  - image: hseeberger/scala-sbt:<< parameters.version >>
+working_directory: <<parameters.working_directory>>

--- a/src/scala/executors/scalafmt.yaml
+++ b/src/scala/executors/scalafmt.yaml
@@ -1,0 +1,14 @@
+description: |
+  The docker container to used to run static checks on Scala projects.
+parameters:
+  version:
+    description: scalafmt version to use (docker tag)
+    type: string
+    default: 2.2.1
+  working_directory:
+    description: directory path for this job
+    type: string
+    default: "~/repo"
+docker:
+  - image: mrothy/scalafmt:<< parameters.version >>
+working_directory: <<parameters.working_directory>>

--- a/src/scala/jobs/static_check.yaml
+++ b/src/scala/jobs/static_check.yaml
@@ -1,0 +1,14 @@
+description: |
+  Run `scalafmt` against the repo. Outputs the issues which change suggestions.
+  To run locally, try:
+    `docker run -v $(PWD)/src:/src --rm -it mrothy/scalafmt-native /src`
+  This is a smaller image, and version might not align with CI, but is a quick way to reproduce.
+parameters:
+  executor:
+    description: Executor to use for this job
+    type: executor
+    default: scalafmt
+executor: << parameters.executor >>
+steps:
+  - checkout
+  - run: scalafmt --test

--- a/src/scala/jobs/test_and_compile.yaml
+++ b/src/scala/jobs/test_and_compile.yaml
@@ -1,0 +1,43 @@
+description: |
+  Compile a fat-jar for adding to a docker image.
+parameters:
+  executor:
+    description: Executor to use for this job
+    type: executor
+    default: scala
+  project_base:
+    description: Where test output gets placed
+    type: string
+    default: common/target
+  with_coverage:
+    description: |
+      Enable the use of code-climate for test coverage analysis
+        requires code-climate CC_TEST_REPORTER_ID env variable to be added to the job
+        the best place for this is in the project in CircleCI UI
+        the code-climate ID is specific to each repo
+    type: boolean
+    default: true
+  path_to_coverage_file:
+    description: Where the test coverage report gets created.
+    type: string
+    default: scala-2.12/coverage-report/cobertura.xml
+
+executor: << parameters.executor >>
+
+steps:
+  - checkout
+  - restore_cache:
+      keys:
+        - dependencies-{{ checksum "build.sbt" }}
+  - test:
+      project_base: << parameters.project_base >>
+      with_coverage: << parameters.with_coverage >>
+      path_to_coverage_file: << parameters.path_to_coverage_file >>
+  - compile
+  - save_cache:
+      paths:
+        - ~/.ivy2
+        - ~/.sbt
+        - ~/.m2
+      key: dependencies-{{ checksum "build.sbt" }}
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Providing a new orb for scala development. Currently has the functionality to run static formatting checks, tests with code-climate coverage, and compile a jar (that will be used in docker image)


**If applicable**:
- [x] All new Jobs, Commands, Executors, Parameters have descriptions
- [x] If PR adds a new feature, Examples have been added
- [x] README has been updated, if necessary
