### PR TITLE
Add dag gitops deploy

### DIFF
--- a/src/deploy/examples/dag_gitops_cd.yaml
+++ b/src/deploy/examples/dag_gitops_cd.yaml
@@ -1,0 +1,19 @@
+description: |
+  Trigger dag gitops CD process by creating a PR in our deploy repo
+usage:
+  version: 2.1
+
+  orbs:
+    ta-deploy: travelaudience/deploy@x.y.z
+
+  workflows:
+    deploy:
+      jobs:
+        - ta-deploy/dag_gitops_deploy:
+            context: git-context
+            dag_name: some-dag-name
+            filters:
+              tags:
+                only: /.*/
+              branches:
+                ignore: /.*/

--- a/src/deploy/executors/github.yaml
+++ b/src/deploy/executors/github.yaml
@@ -1,0 +1,9 @@
+description: |
+  The docker container to interact with github API
+docker:
+  - image: 'abergmeier/hub:<< parameters.tag >>'
+parameters:
+  tag:
+    default: 2.12.8
+    description: abergmeier/hub version (docker tag)
+    type: string

--- a/src/deploy/jobs/dag_gitops_deploy.yaml
+++ b/src/deploy/jobs/dag_gitops_deploy.yaml
@@ -1,0 +1,50 @@
+description: |
+  Starts a dag deploy flow using gitops approach.
+parameters:
+  github_token:
+    description: |
+      Name of environment variable storing your secret githun token.
+    type: env_var_name
+    default: GIT_PUSH_TOKEN
+  github_email:
+    description: |
+      Name of environment variable storing your github email
+    type: env_var_name
+    default: GIT_EMAIL
+  dag_name:
+    description: |
+      Name of the dag to be used to change .ini files.
+      This dag name will be used to define dag folder name on composer bucket.
+      Dag name must be same as your repo name.
+    type: string
+  version:
+    description: |
+      Version of the dag to deploy
+    type: string
+    default: $CIRCLE_TAG
+  gitops_repo:
+    description: |
+      Name of environment variable storing repo to apply CD using gitops
+    type: env_var_name
+    default: GIT_DAG_GITOPS
+  executor:
+    description: Github executor to use for this job
+    type: executor
+    default: github
+executor: << parameters.executor >>
+steps:
+  - run: git clone https://$<<parameters.github_token>>@$<<parameters.gitops_repo>>
+  - run: git config --global user.email '$<<parameters.github_email>>'
+  - run:
+      name: "Change config files"
+      command: |
+        cd dag-cd
+        git checkout -b <<parameters.dag_name>>-<<parameters.version>>
+        cd <<parameters.dag_name>>;sed -i -e 's/docker_tag=.*/docker_tag=<<parameters.version>>/g' *.ini
+  - run:
+      name: "Create Pull Request"
+      command: |
+        cd dag-cd
+        git add .
+        git commit -m "project:<<parameters.dag_name>> version:<<parameters.version>>"
+        GITHUB_TOKEN=$<<parameters.github_token>> hub pull-request -m "project:<<parameters.dag_name>> version:<<parameters.version>>" -p


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Add Dag GitOps deploy job to allow the use of gitops approach to deploy google composer dags.

**Special notes for your reviewer**:

**If applicable**:
- [x] All new Jobs, Commands, Executors, Parameters have descriptions
- [x] If PR adds a new feature, Examples have been added
- [x] README has been updated, if necessary
