### PR TITLE
Install requirements when running pylint

### DIFF
--- a/src/python/executors/pylint.yaml
+++ b/src/python/executors/pylint.yaml
@@ -1,9 +1,0 @@
-description: |
-  The docker container to perform linting with pylint for Python projects.
-docker:
-  - image: 'cytopia/pylint:<< parameters.tag >>'
-parameters:
-  tag:
-    default: latest
-    description: The lastest version of pylint
-    type: string

--- a/src/python/jobs/pylint.yaml
+++ b/src/python/jobs/pylint.yaml
@@ -8,6 +8,12 @@ parameters:
     description: |
       Define location for the source code to perform linting with pylint
     type: string
+  with_custom_repository:
+    description: |
+      Enable the use a custom repository to install `requirements-ci.txt` and `requirements.txt`.
+      The repository url must be set via context
+    type: boolean
+    default: false
   repository_url:
     description: |
       Name of environment variable storing your python repository url.
@@ -17,9 +23,17 @@ parameters:
   executor:
     description: Pylint executor to use for this job
     type: executor
-    default: pylint
+    default: python/default
 executor: << parameters.executor >>
 steps:
   - checkout
-  - run: pip install --user -r requirements.txt --index-url $<< parameters.repository_url >>
+  - run: pip install --user pylint
+  - when:
+      condition: << parameters.with_custom_repository >>
+      steps:
+        - run: pip install --user -r requirements.txt --index-url $<< parameters.repository_url >>
+  - unless:
+      condition: << parameters.with_custom_repository >>
+      steps:
+        - run: pip install --user -r requirements.txt
   - run: pylint << parameters.source >>

--- a/src/python/jobs/pylint.yaml
+++ b/src/python/jobs/pylint.yaml
@@ -8,6 +8,12 @@ parameters:
     description: |
       Define location for the source code to perform linting with pylint
     type: string
+  repository_url:
+    description: |
+      Name of environment variable storing your python repository url.
+      This url should include credentials if applicable.
+    type: env_var_name
+    default: PY_NEXUS_URL_WITH_SECRETS
   executor:
     description: Pylint executor to use for this job
     type: executor
@@ -15,4 +21,5 @@ parameters:
 executor: << parameters.executor >>
 steps:
   - checkout
+  - run: pip install --user -r requirements.txt --index-url $<< parameters.repository_url >>
   - run: pylint << parameters.source >>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

During `pylint` we need to have the dependencies installed. For that we need to properly install the requirements.txt when running the `pylint` job.

On this PR we are:
- Changing pylint job to a `python/default` executor
- Installing `requirements`
- Allowing to install `requirements` from custom repository

**Special notes for your reviewer**:

**If applicable**:
- [x] All new Jobs, Commands, Executors, Parameters have descriptions
- [x] If PR adds a new feature, Examples have been added
- [x] README has been updated, if necessary
