### PR TITLE
Added parameter to skip staticcheck

### DIFF
--- a/src/go/commands/staticcheck.yaml
+++ b/src/go/commands/staticcheck.yaml
@@ -4,7 +4,18 @@ parameters:
     description: Version of staticcheck to install
     default: "2019.2.1"
     type: string
+  run-static-analysis:
+    description: If false static analysis is not executed
+    default: true
+    type: bool
 steps:
-  # directory change required due to https://github.com/dominikh/go-tools/issues/528
-  - run: cd ../ && go get -u honnef.co/go/tools/cmd/staticcheck@<<parameters.version>>
-  - run: staticcheck -unused.whole-program ./...
+  - when:
+    condition: run-static-analysis
+    steps:
+      # directory change required due to https://github.com/dominikh/go-tools/issues/528
+      - run: cd ../ && go get -u honnef.co/go/tools/cmd/staticcheck@<<parameters.version>>
+      - run: staticcheck -unused.whole-program ./...
+  - unless:
+    condition: run-static-analysis
+    steps:
+      - run: echo "skipped static-analysis"

--- a/src/go/commands/staticcheck.yaml
+++ b/src/go/commands/staticcheck.yaml
@@ -4,19 +4,7 @@ parameters:
     description: Version of staticcheck to install
     default: "2019.2.1"
     type: string
-  run-static-analysis:
-    description: If false static analysis is not executed
-    default: true
-    type: boolean
 steps:
-  - run: echo "test"
-  - when:
-      condition: run-static-analysis
-      steps:
-        # directory change required due to https://github.com/dominikh/go-tools/issues/528
-        - run: cd ../ && go get -u honnef.co/go/tools/cmd/staticcheck@<<parameters.version>>
-        - run: staticcheck -unused.whole-program ./...
-  - unless:
-      condition: run-static-analysis
-      steps:
-        - run: echo "skipped static-analysis"
+  # directory change required due to https://github.com/dominikh/go-tools/issues/528
+  - run: cd ../ && go get -u honnef.co/go/tools/cmd/staticcheck@<<parameters.version>>
+  - run: staticcheck -unused.whole-program ./...

--- a/src/go/commands/staticcheck.yaml
+++ b/src/go/commands/staticcheck.yaml
@@ -7,15 +7,16 @@ parameters:
   run-static-analysis:
     description: If false static analysis is not executed
     default: true
-    type: bool
+    type: boolean
 steps:
+  - run: echo "test"
   - when:
-    condition: run-static-analysis
-    steps:
-      # directory change required due to https://github.com/dominikh/go-tools/issues/528
-      - run: cd ../ && go get -u honnef.co/go/tools/cmd/staticcheck@<<parameters.version>>
-      - run: staticcheck -unused.whole-program ./...
+      condition: run-static-analysis
+      steps:
+        # directory change required due to https://github.com/dominikh/go-tools/issues/528
+        - run: cd ../ && go get -u honnef.co/go/tools/cmd/staticcheck@<<parameters.version>>
+        - run: staticcheck -unused.whole-program ./...
   - unless:
-    condition: run-static-analysis
-    steps:
-      - run: echo "skipped static-analysis"
+      condition: run-static-analysis
+      steps:
+        - run: echo "skipped static-analysis"

--- a/src/go/jobs/checks.yaml
+++ b/src/go/jobs/checks.yaml
@@ -14,8 +14,8 @@ steps:
   - go/load-cache
   - vet
   - when:
-    condition: << parameters.run-static-analysis >>
-    steps:
-      - staticcheck:
+      condition: << parameters.run-static-analysis >>
+      steps:
+        - staticcheck
   # - lint
   - go/save-cache

--- a/src/go/jobs/checks.yaml
+++ b/src/go/jobs/checks.yaml
@@ -4,11 +4,16 @@ parameters:
     description: Executor to use for this job
     type: executor
     default: go_executor
+  run-static-analysis:
+    description: If false static analysis is not executed
+    default: true
+    type: bool
 executor: << parameters.exec >>
 steps:
   - checkout
   - go/load-cache
   - vet
-  - staticcheck
+  - staticcheck:
+      run-static-analysis: << parameters.run-static-analysis >>
   # - lint
   - go/save-cache

--- a/src/go/jobs/checks.yaml
+++ b/src/go/jobs/checks.yaml
@@ -13,7 +13,9 @@ steps:
   - checkout
   - go/load-cache
   - vet
-  - staticcheck:
-      run-static-analysis: << parameters.run-static-analysis >>
+  - when: 
+    condition:  << parameters.run-static-analysis >>
+    steps:
+      - staticcheck:
   # - lint
   - go/save-cache

--- a/src/go/jobs/checks.yaml
+++ b/src/go/jobs/checks.yaml
@@ -13,8 +13,8 @@ steps:
   - checkout
   - go/load-cache
   - vet
-  - when: 
-    condition:  << parameters.run-static-analysis >>
+  - when:
+    condition: << parameters.run-static-analysis >>
     steps:
       - staticcheck:
   # - lint

--- a/src/go/jobs/checks.yaml
+++ b/src/go/jobs/checks.yaml
@@ -7,7 +7,7 @@ parameters:
   run-static-analysis:
     description: If false static analysis is not executed
     default: true
-    type: bool
+    type: boolean
 executor: << parameters.exec >>
 steps:
   - checkout


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->
refers to: [RTT-219/bidder (circleci migration)](https://travelaudience.atlassian.net/secure/RapidBoard.jspa?rapidView=88&projectKey=RTT&modal=detail&selectedIssue=RTT-219)

**What this PR does / why we need it**:
Bidder is full of static check complains which we are adressing later. In order to finish the migration to circleci, we need the option to skip static-analysi like we had on jenkins.

**Special notes for your reviewer**:

**If applicable**:

New Parameter `run-static-analysis` added to ta-go/checks. This will be forwarded to 
`staticcheck` and run or don't run static analysis
- [ ] All new Jobs, Commands, Executors, Parameters have descriptions
- [ ] If PR adds a new feature, Examples have been added
- [ ] README has been updated, if necessary
