### PR TITLE
Fix helm package git dif by hiding deleted files

### DIFF
--- a/src/helm/commands/package.yaml
+++ b/src/helm/commands/package.yaml
@@ -66,7 +66,7 @@ steps:
         # 'ct list-changed' doesn't work on master branch
         #   see https://github.com/helm/chart-testing/pull/159
         if [ "$CIRCLE_BRANCH" == "master" ]; then
-            git diff --name-only $(git merge-base HEAD^ HEAD) -- <<parameters.chart_dir_override>>  | while IFS= read -r file ; do
+            git diff --diff-filter=d --name-only $(git merge-base HEAD^ HEAD) -- <<parameters.chart_dir_override>>  | while IFS= read -r file ; do
                 if echo "$file" | grep -q "/Chart.yaml"; then
                     chart=$(echo "$file" | sed 's/\/Chart.yaml$//')
                     package_chart $chart


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
When a chart is deleted from a repo the diff will present deleted `Chart.yaml` files. This files are being used to actually package charts, so we need to ignore the ones listed as deleted.

**Special notes for your reviewer**:

**If applicable**:
- [x] All new Jobs, Commands, Executors, Parameters have descriptions
- [x] If PR adds a new feature, Examples have been added
- [x] README has been updated, if necessary
