### PR TITLE
Replaced cd + sed by find + sed to support multi-dag folder setup

### DIFF
--- a/src/deploy/jobs/dag_gitops_deploy.yaml
+++ b/src/deploy/jobs/dag_gitops_deploy.yaml
@@ -40,7 +40,7 @@ steps:
       command: |
         cd dag-cd
         git checkout -b <<parameters.dag_name>>-<<parameters.version>>
-        cd <<parameters.dag_name>>;sed -i -e "s/docker_tag=.*/docker_tag=<<parameters.version>>/g" *.ini
+        find "<<parameters.dag_name>>/" -name "*.ini" -exec sed -i -e "s/docker_tag=.*/docker_tag=<<parameters.version>>/g" {} +
   - run:
       name: "Create Pull Request"
       command: |


### PR DESCRIPTION
The old line would crash if there is no ini file directly at the root of the dag folder in the dag-cd repo. With the multi-dag repo setup an ini file at the root is not required. For example:
https://app.circleci.com/pipelines/github/travelaudience/workflow-bigquery-monitoring/16/workflows/49f278e0-984b-42b4-8a66-69a16245b619/jobs/13

This PR will look for ini files recursively in the <<parameters.dag_name>> folder, and also not crash if there is no ini file at all.