### PR TITLE
Replace index-url to extra-index-url

### DIFF
--- a/src/python/jobs/pylint.yaml
+++ b/src/python/jobs/pylint.yaml
@@ -31,7 +31,7 @@ steps:
   - when:
       condition: << parameters.with_custom_repository >>
       steps:
-        - run: pip install --user -r requirements.txt --index-url $<< parameters.repository_url >>
+        - run: pip install --user -r requirements.txt --extra-index-url $<< parameters.repository_url >>
   - unless:
       condition: << parameters.with_custom_repository >>
       steps:

--- a/src/python/jobs/test.yaml
+++ b/src/python/jobs/test.yaml
@@ -66,11 +66,11 @@ steps:
       steps:
         - orb-tools/check-env-var-param:
             param: << parameters.repository_url >>
-        - run: pip install --user -r requirements.txt --index-url $<< parameters.repository_url >>
+        - run: pip install --user -r requirements.txt --extra-index-url $<< parameters.repository_url >>
         - when:
             condition: << parameters.ci_requirements >>
             steps:
-              - run: pip install --user -r << parameters.ci_requirements >> --index-url $<< parameters.repository_url >>
+              - run: pip install --user -r << parameters.ci_requirements >> --extra-index-url $<< parameters.repository_url >>
   - unless:
       condition: << parameters.with_custom_repository >>
       steps:


### PR DESCRIPTION
Fix for python orb to use an addition pip index instead of replace the default one.