### PR TITLE
Fix assembly cmd to work for submodule names with '-' inside

### DIFF
--- a/src/scala/commands/compile.yaml
+++ b/src/scala/commands/compile.yaml
@@ -10,7 +10,7 @@ steps:
       command: |
         submodule=$([ "<< parameters.submodule >>" ] && echo "<< parameters.submodule >> /" || echo "")
         version=$(git describe --tags --always)
-        sbt 'set '"$submodule"' assembly / target := new File("target/fat-jar")' 'set ThisBuild / version := "'${version}'"' "$submodule"' assembly'
+        sbt "project $submodule" 'set assembly / target := new File("target/fat-jar")' 'set ThisBuild / version := "'${version}'"' assembly
   - store_artifacts:
       path: target/fat-jar
   - persist_to_workspace:

--- a/src/scala/commands/compile.yaml
+++ b/src/scala/commands/compile.yaml
@@ -8,7 +8,7 @@ steps:
   - run:
       name: '[scala] Assembly'
       command: |
-        submodule=$([ "<< parameters.submodule >>" ] && echo "<< parameters.submodule >> /" || echo "")
+        submodule=$([ "<< parameters.submodule >>" ] && echo "<< parameters.submodule >>" || echo "")
         version=$(git describe --tags --always)
         sbt "project $submodule" 'set assembly / target := new File("target/fat-jar")' 'set ThisBuild / version := "'${version}'"' assembly
   - store_artifacts:

--- a/src/scala/executors/scala.yaml
+++ b/src/scala/executors/scala.yaml
@@ -4,7 +4,7 @@ parameters:
   version:
     description: jdk/sbt/scala version to use (docker tag)
     type: string
-    default: 8u222_1.3.3_2.12.10
+    default: 8u252_1.3.12_2.12.11
   resource_class:
     description: which circleci resource_class to use
     type: string


### PR DESCRIPTION
sbt assembly is failing for sub modules with `-` in the name. This PR should fix this. 