### PR TITLE
Update nexus env vars to use one default for artefacts type.

### DIFF
--- a/src/docker/jobs/build_and_push.yaml
+++ b/src/docker/jobs/build_and_push.yaml
@@ -19,11 +19,11 @@ parameters:
   docker-username:
     description: Name of environment variable storing your Docker username
     type: env_var_name
-    default: DOCKER_LOGIN
+    default: NEXUS_USERNAME
   docker-password:
     description: Name of environment variable storing your Docker password
     type: env_var_name
-    default: DOCKER_PASSWORD
+    default: NEXUS_PASSWORD
   extra-tag:
     description: Additional tag to apply to the image besides the default SHA tag. Defaults to the change name (git branch OR tag)
     type: string

--- a/src/docker/jobs/docker_git_tag.yaml
+++ b/src/docker/jobs/docker_git_tag.yaml
@@ -16,11 +16,11 @@ parameters:
   docker-username:
     description: Name of environment variable storing your Docker username
     type: env_var_name
-    default: DOCKER_LOGIN
+    default: NEXUS_USERNAME
   docker-password:
     description: Name of environment variable storing your Docker password
     type: env_var_name
-    default: DOCKER_PASSWORD
+    default: NEXUS_PASSWORD
   registry:
     description: Name of environment variable storing the registry host
     type: env_var_name

--- a/src/docker/jobs/docker_scan.yaml
+++ b/src/docker/jobs/docker_scan.yaml
@@ -3,11 +3,11 @@ parameters:
   docker-username:
     description: Name of environment variable storing your Docker username
     type: env_var_name
-    default: DOCKER_LOGIN
+    default: NEXUS_USERNAME
   docker-password:
     description: Name of environment variable storing your Docker password
     type: env_var_name
-    default: DOCKER_PASSWORD
+    default: NEXUS_PASSWORD
   registry:
     description: Name of environment variable storing the registry host
     type: env_var_name

--- a/src/python/jobs/publish.yaml
+++ b/src/python/jobs/publish.yaml
@@ -8,11 +8,11 @@ parameters:
   repository_username:
     description: Name of environment variable storing your python repository username
     type: env_var_name
-    default: PY_NEXUS_USERNAME
+    default: NEXUS_USERNAME
   repository_password:
     description: Name of environment variable storing your python repository password
     type: env_var_name
-    default: PY_NEXUS_PASSWORD
+    default: NEXUS_PASSWORD
   repository_url:
     description: Name of environment variable storing your python repository url
     type: env_var_name


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
We decided to use one global env-var for Nexus username and password for all types of artefacts.
!This is a breaking change and require an update of the name of the environment variable on project/organization level on circleci.!
**Special notes for your reviewer**:

**If applicable**:
- [ ] All new Jobs, Commands, Executors, Parameters have descriptions
- [ ] If PR adds a new feature, Examples have been added
- [ ] README has been updated, if necessary
