### PR TITLE
removed mockery from make-gen

### DIFF
--- a/src/go/commands/make-gen.yaml
+++ b/src/go/commands/make-gen.yaml
@@ -9,7 +9,6 @@ steps:
       name: '[go] install deps'
       command: |
         cd ../
-        go get -u github.com/vektra/mockery/cmd/mockery \
         golang.org/x/tools/cmd/goimports \
         github.com/golang/protobuf/protoc-gen-go@<<parameters.protoc_version>>
   - run: make gen


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR removes Mockery from the `make-gen` command since it is not needed and leads to pipelines fail.

**Special notes for your reviewer**:
The error which happens because of this:
https://app.circleci.com/pipelines/github/travelaudience/ot-locationserv/59/workflows/7b24e0ae-2ef3-4481-a4f9-e75c4a71d50e/jobs/344

**If applicable**:
- [ ] All new Jobs, Commands, Executors, Parameters have descriptions
- [ ] If PR adds a new feature, Examples have been added
- [ ] README has been updated, if necessary
