### PR TITLE
Allow to setup stable branch for specific chart

### DIFF
--- a/src/helm/commands/package.yaml
+++ b/src/helm/commands/package.yaml
@@ -22,6 +22,10 @@ parameters:
     description: The path where packaged charts will be saved (defaults to a local, relative path)
     type: string
     default: ".cr-release-packages"
+  chart_stable_branch:
+    description: The branch that should be used to store a chart in stable repository
+    type: string
+    default: "master"
 steps:
   - run:
       shell: /bin/sh
@@ -37,7 +41,7 @@ steps:
             helm dependency build "$chart"
 
             # set the version different for incubator
-            if [ "$CIRCLE_BRANCH" == "master" ]; then
+            if [ "$CIRCLE_BRANCH" == <<parameters.chart_stable_branch>> ]; then
               helm package "$chart" --destination <<parameters.chart_package_path>>
             else
               ver=$(helm inspect chart "$chart" | grep version | cut -d' ' -f2)
@@ -63,9 +67,9 @@ steps:
         fi
         rm -rf <<parameters.chart_package_path>>; mkdir <<parameters.chart_package_path>>
 
-        # 'ct list-changed' doesn't work on master branch
+        # 'ct list-changed' doesn't work on main branch
         #   see https://github.com/helm/chart-testing/pull/159
-        if [ "$CIRCLE_BRANCH" == "master" ]; then
+        if [ "$CIRCLE_BRANCH" == <<parameters.chart_stable_branch>> ]; then
             git diff --diff-filter=d --name-only $(git merge-base HEAD^ HEAD) -- <<parameters.chart_dir_override>>  | while IFS= read -r file ; do
                 if echo "$file" | grep -q "/Chart.yaml"; then
                     chart=$(echo "$file" | sed 's/\/Chart.yaml$//')

--- a/src/helm/commands/push.yaml
+++ b/src/helm/commands/push.yaml
@@ -13,6 +13,10 @@ parameters:
   retry_count:
     type: integer
     default: 8
+  chart_stable_branch:
+    description: The branch that should be used to store a chart in stable repository
+    type: string
+    default: "master"
 steps:
   - run: git clone --depth <<parameters.clone_depth>> <<parameters.chart_git_repo>> .helmPath
   - run:
@@ -29,7 +33,7 @@ steps:
 
             git fetch
             git reset --hard origin/master
-            if [ "$CIRCLE_BRANCH" == "master" ]; then
+            if [ "$CIRCLE_BRANCH" == <<parameters.chart_stable_branch>> ]; then
               cp ../<<parameters.chart_package_path>>/* stable/
               cd stable
               helm repo index .

--- a/src/helm/jobs/package_and_push.yaml
+++ b/src/helm/jobs/package_and_push.yaml
@@ -19,6 +19,10 @@ parameters:
       Defaulting to searching in 'helm' dir to look for changes.
     type: string
     default: "helm"
+  chart_stable_branch:
+    description: The branch that should be used to store a chart in stable repository
+    type: string
+    default: "master"
   exec:
     description: The name of custom executor to use
     type: executor
@@ -29,5 +33,7 @@ steps:
   - package:
       chart_test_config: <<parameters.chart_test_config>>
       chart_dir_override: <<parameters.chart_dir_override>>
+      chart_stable_branch: <<parameters.chart_stable_branch>>
   - push:
       chart_git_repo: <<parameters.chart_git_repo>>
+      chart_stable_branch: <<parameters.chart_stable_branch>>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Currently the master branch is hardcoded in code when packaging and publishing helm charts. Since, now we can support multiple `main` branches (master, main, wtv) we need to add support to define it as a variable.

**Special notes for your reviewer**:

**If applicable**:
- [x] All new Jobs, Commands, Executors, Parameters have descriptions
- [x] If PR adds a new feature, Examples have been added
- [x] README has been updated, if necessary
