### PR TITLE
Fix scala orb when coverage is turned off in publish library workflow.

### DIFF
--- a/src/scala/jobs/run_static_checks.yaml
+++ b/src/scala/jobs/run_static_checks.yaml
@@ -52,7 +52,7 @@ steps:
       steps:
         - run:
             name: Run tests
-            command: sbt coverageOn +test coverageOff coverageAggregate
+            command: sbt +test
 
   - run:
       name: Save test results


### PR DESCRIPTION
When coverage is turned off workflow should execute plain `sbt +test`.