### PR TITLE
Set default version to 0.7.0

### DIFF
--- a/src/code-climate/commands/install.yaml
+++ b/src/code-climate/commands/install.yaml
@@ -1,7 +1,7 @@
 description: Install the Code Climate rest reporter.
 parameters:
   version:
-    default: latest
+    default: 0.7.0
     description: The version of Code Climate test reporter to download. (default latest)
     type: string
 steps:


### PR DESCRIPTION
The most recent release of the code-climate reporter is now a zipped file, which breaks some of our CI/CD pipelines.

I would prefer to default to a fixed version of the reporter so this doesn't happen again.
