### PR TITLE
hacky solution to fix obsolete helm version

### DIFF
--- a/src/helm/commands/package.yaml
+++ b/src/helm/commands/package.yaml
@@ -54,12 +54,12 @@ steps:
             echo "'$chart' packaged"
             echo "-----"
         }
-        
+
         # Hack to upgrade helm version
         rm /usr/local/bin/helm
         curl -LO "https://kubernetes-helm.storage.googleapis.com/helm-v2.17.0-linux-amd64.tar.gz" && mkdir -p "/usr/local/helm-v2.17.0" && tar -xzf "helm-v2.17.0-linux-amd64.tar.gz" -C "/usr/local/helm-v2.17.
         0" && ln -s "/usr/local/helm-v2.17.0/linux-amd64/helm" /usr/local/bin/helm && rm -f "helm-v2.17.0-linux-amd64.tar.gz"
-        
+
         helm init --client-only  || true  # this step is required for helm v2
         helm version -c
         if [ "$CT_CHART_REPOS" ]; then

--- a/src/helm/commands/package.yaml
+++ b/src/helm/commands/package.yaml
@@ -54,7 +54,12 @@ steps:
             echo "'$chart' packaged"
             echo "-----"
         }
-
+        
+        # Hack to upgrade helm version
+        rm /usr/local/bin/helm
+        curl -LO "https://kubernetes-helm.storage.googleapis.com/helm-v2.17.0-linux-amd64.tar.gz" && mkdir -p "/usr/local/helm-v2.17.0" && tar -xzf "helm-v2.17.0-linux-amd64.tar.gz" -C "/usr/local/helm-v2.17.
+        0" && ln -s "/usr/local/helm-v2.17.0/linux-amd64/helm" /usr/local/bin/helm && rm -f "helm-v2.17.0-linux-amd64.tar.gz"
+        
         helm init --client-only  || true  # this step is required for helm v2
         helm version -c
         if [ "$CT_CHART_REPOS" ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Helm prior to 2.17 are no longer supported as stated here:
https://helm.sh/blog/new-location-stable-incubator-charts/

Since there is no image available with 2.17 version I am adding a hacky solution to fix it for now. 
**Special notes for your reviewer**:

**If applicable**:
- [ ] All new Jobs, Commands, Executors, Parameters have descriptions
- [ ] If PR adds a new feature, Examples have been added
- [ ] README has been updated, if necessary
