### PR TITLE
Put mockery back (Go)

### DIFF
--- a/src/go/commands/make-gen.yaml
+++ b/src/go/commands/make-gen.yaml
@@ -9,6 +9,7 @@ steps:
       name: '[go] install deps'
       command: |
         cd ../
-        go get -u golang.org/x/tools/cmd/goimports \
+        go get -u github.com/vektra/mockery/cmd/mockery \
+        golang.org/x/tools/cmd/goimports \
         github.com/golang/protobuf/protoc-gen-go@<<parameters.protoc_version>>
   - run: make gen


### PR DESCRIPTION
Puts mockery back into make-gen.yaml, as that appears to be what's breaking our CI.