### PR TITLE
(Scala) Store coverage results as artifacts in library workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# IDE
+.idea
+*iml

--- a/src/scala/jobs/run_static_checks.yaml
+++ b/src/scala/jobs/run_static_checks.yaml
@@ -63,17 +63,13 @@ steps:
             command: sbt +test
 
   - run:
-      name: Find test results
+      name: Save test results
       command: |
         mkdir -p test-reports
         find . -type f -regex ".*/target/test-reports/.*xml" -exec cp {} test-reports/ \;
 
   - store_test_results:
       path: test-reports
-
-  - store_artifacts:
-      path: test-reports
-      destination: test-reports
 
   - write_cache:
       cache_key: << parameters.cache_key >>

--- a/src/scala/jobs/run_static_checks.yaml
+++ b/src/scala/jobs/run_static_checks.yaml
@@ -70,7 +70,7 @@ steps:
 
   - store_test_results:
       path: test-reports
-      
+
   # TODO add codeclimate (check how to make wildcard for any scala version)
 
   - write_cache:

--- a/src/scala/jobs/run_static_checks.yaml
+++ b/src/scala/jobs/run_static_checks.yaml
@@ -55,6 +55,9 @@ steps:
         - store_artifacts:
             path: coverage-reports/scoverage-report
             destination: scoverage-report
+        - run:
+            name: Clean coverage results
+            command: rm -rf coverage-reports
   - unless:
       condition: << parameters.with_sbtcoverage >>
       steps:

--- a/src/scala/jobs/run_static_checks.yaml
+++ b/src/scala/jobs/run_static_checks.yaml
@@ -51,7 +51,7 @@ steps:
             name: Save coverage results
             command: |
               mkdir -p coverage-reports
-              cp -r "$(find . -type d -name 'scoverage-report' -print) coverage-reports/"
+              cp -r "$(find . -type d -name 'scoverage-report' -print)" coverage-reports/
         - store_artifacts:
             path: coverage-reports/scoverage-report
             destination: scoverage-report

--- a/src/scala/jobs/run_static_checks.yaml
+++ b/src/scala/jobs/run_static_checks.yaml
@@ -47,6 +47,14 @@ steps:
         - run:
             name: Check code coverage and run tests
             command: sbt coverageOn +test coverageOff coverageAggregate
+        - run:
+            name: Save coverage results
+            command: |
+              mkdir -p coverage-reports
+              cp -r "$(find . -type d -name 'scoverage-report' -print) coverage-reports/"
+        - store_artifacts:
+            path: coverage-reports/scoverage-report
+            destination: scoverage-report
   - unless:
       condition: << parameters.with_sbtcoverage >>
       steps:
@@ -55,7 +63,7 @@ steps:
             command: sbt +test
 
   - run:
-      name: Save test results
+      name: Find test results
       command: |
         mkdir -p test-reports
         find . -type f -regex ".*/target/test-reports/.*xml" -exec cp {} test-reports/ \;
@@ -63,7 +71,9 @@ steps:
   - store_test_results:
       path: test-reports
 
-  # TODO add codeclimate (check how to make wildcard for any scala version)
+  - store_artifacts:
+      path: test-reports
+      destination: test-reports
 
   - write_cache:
       cache_key: << parameters.cache_key >>

--- a/src/scala/jobs/run_static_checks.yaml
+++ b/src/scala/jobs/run_static_checks.yaml
@@ -70,6 +70,8 @@ steps:
 
   - store_test_results:
       path: test-reports
+      
+  # TODO add codeclimate (check how to make wildcard for any scala version)
 
   - write_cache:
       cache_key: << parameters.cache_key >>


### PR DESCRIPTION
For publish scala library worfklow you will be able to inspect coverage report in circleci ui.
  
![Screenshot from 2021-03-05 08-33-37](https://user-images.githubusercontent.com/2332638/110083684-4c5eab00-7d8f-11eb-8a73-c85adfe94ec0.png)
