### PR TITLE
(Scala) Add coursier jar cache folder and bump default scala version in fat-jar workflows

### DIFF
--- a/src/scala/commands/test.yaml
+++ b/src/scala/commands/test.yaml
@@ -18,7 +18,7 @@ parameters:
   path_to_coverage_file:
     description: Where the test coverage report gets created.
     type: string
-    default: scala-2.12/coverage-report/cobertura.xml
+    default: scala-2.13/coverage-report/cobertura.xml
   memory_limit_for_heap:
     description: aggregating the test coverage requires more memory to be defined
     type: string

--- a/src/scala/examples/only_test.yaml
+++ b/src/scala/examples/only_test.yaml
@@ -23,6 +23,7 @@ usage:
               - ~/.ivy2
               - ~/.sbt
               - ~/.m2
+              - ~/.cache/coursier
             key: dependencies-{{ checksum "build.sbt" }}
 
   workflows:

--- a/src/scala/executors/scala.yaml
+++ b/src/scala/executors/scala.yaml
@@ -4,7 +4,7 @@ parameters:
   version:
     description: jdk/sbt/scala version to use (docker tag)
     type: string
-    default: 8u252_1.3.12_2.12.11
+    default: 8u265_1.4.3_2.13.3
   resource_class:
     description: which circleci resource_class to use
     type: string

--- a/src/scala/jobs/compile_only.yaml
+++ b/src/scala/jobs/compile_only.yaml
@@ -23,5 +23,6 @@ steps:
         - ~/.ivy2
         - ~/.sbt
         - ~/.m2
+        - ~/.cache/coursier
       key: dependencies-{{ checksum "build.sbt" }}
 

--- a/src/scala/jobs/static_check.yaml
+++ b/src/scala/jobs/static_check.yaml
@@ -43,4 +43,5 @@ steps:
         - ~/.ivy2
         - ~/.sbt
         - ~/.m2
+        - ~/.cache/coursier
       key: dependencies-{{ checksum "build.sbt" }}

--- a/src/scala/jobs/test_and_compile.yaml
+++ b/src/scala/jobs/test_and_compile.yaml
@@ -21,7 +21,7 @@ parameters:
   path_to_coverage_file:
     description: Where the test coverage report gets created.
     type: string
-    default: scala-2.12/coverage-report/cobertura.xml
+    default: scala-2.13/coverage-report/cobertura.xml
   submodule:
     description: sbt submodule to assembly. Leave empty for main module.
     type: string

--- a/src/scala/jobs/test_and_compile.yaml
+++ b/src/scala/jobs/test_and_compile.yaml
@@ -56,5 +56,6 @@ steps:
         - ~/.ivy2
         - ~/.sbt
         - ~/.m2
+        - ~/.cache/coursier
       key: dependencies-{{ checksum "build.sbt" }}
 


### PR DESCRIPTION
This step should be almost 0s because of caching instead of downloading the jars everytime, coursier cache folder was missing in old orb.

![Screenshot from 2021-03-18 09-01-07](https://user-images.githubusercontent.com/2332638/111592105-a1a3af00-87c8-11eb-8125-3fed96025591.png)

Bumping default scala orb version to 2.13 as well.