### PR TITLE
[DET-1058] Upload test/coverage report in case tests/coverageMinimum fails

### DIFF
--- a/src/scala/commands/test.yaml
+++ b/src/scala/commands/test.yaml
@@ -19,10 +19,10 @@ parameters:
     description: Where the test coverage report gets created.
     type: string
     default: scala-2.13/coverage-report/cobertura.xml
-  memory_limit_for_heap:
-    description: aggregating the test coverage requires more memory to be defined
+  sbt_opts:
+    description: aggregating the test coverage requires more memory and stack size to be defined
     type: string
-    default: 1524M
+    default: "-Xmx1524M -Xms512m -Xss4m"
 
 steps:
   - when:
@@ -37,7 +37,7 @@ steps:
         - run:
             name: Try running tests with coverage
             command: |
-              export SBT_OPTS="-Xmx<<parameters.memory_limit_for_heap>>"
+              export SBT_OPTS="<<parameters.sbt_opts>>"
               if sbt coverageOn +test coverageOff coverageAggregate
               then
                 echo 'export TESTS_STATUS=0' >> $BASH_ENV
@@ -48,7 +48,7 @@ steps:
       condition: << parameters.with_coverage >>
       steps:
         - run:
-            name: Try tunning tests without coverage
+            name: Try running tests without coverage
             command: |
               if sbt +test
               then

--- a/src/scala/commands/test.yaml
+++ b/src/scala/commands/test.yaml
@@ -19,10 +19,6 @@ parameters:
     description: Where the test coverage report gets created.
     type: string
     default: scala-2.13/coverage-report/cobertura.xml
-  sbt_opts:
-    description: aggregating the test coverage requires more memory and stack size to be defined
-    type: string
-    default: "-Xmx1524M -Xms512m -Xss4m"
 
 steps:
   - when:
@@ -37,7 +33,6 @@ steps:
         - run:
             name: Try running tests with coverage
             command: |
-              export SBT_OPTS="<<parameters.sbt_opts>>"
               if sbt coverageOn +test coverageOff coverageAggregate
               then
                 echo 'export TESTS_STATUS=0' >> $BASH_ENV

--- a/src/scala/commands/test.yaml
+++ b/src/scala/commands/test.yaml
@@ -37,7 +37,9 @@ steps:
         - run:
             name: Try running tests with coverage
             command: |
-              if SBT_OPTS="-Xmx<<parameters.memory_limit_for_heap>>" sbt coverageOn +test coverageOff coverageAggregate; then
+              export SBT_OPTS="-Xmx<<parameters.memory_limit_for_heap>>"
+              if sbt coverageOn +test coverageOff coverageAggregate
+              then
                 echo 'export TESTS_STATUS=0' >> $BASH_ENV
               else
                 echo 'export TESTS_STATUS=1' >> $BASH_ENV
@@ -48,7 +50,8 @@ steps:
         - run:
             name: Try tunning tests without coverage
             command: |
-              if sbt test ; then
+              if sbt +test
+              then
                 echo 'export TESTS_STATUS=0' >> $BASH_ENV
               else
                 echo 'export TESTS_STATUS=1' >> $BASH_ENV

--- a/src/scala/commands/test.yaml
+++ b/src/scala/commands/test.yaml
@@ -40,8 +40,14 @@ steps:
                 echo 'export TESTS_STATUS=1' >> $BASH_ENV
               fi
         - run:
-            name: Aggregate coverage reports
-            command: sbt coverageAggregate
+            name: Check for minimum coverage and aggregate coverage reports
+            command: |
+              if sbt coverageAggregate
+              then
+                echo 'export COVERAGE_STATUS=0' >> $BASH_ENV
+              else
+                echo 'export COVERAGE_STATUS=1' >> $BASH_ENV
+              fi
         - code-climate/format_coverage:
             coverage_file: << parameters.project_base >>/<< parameters.path_to_coverage_file >>
             input_type: cobertura
@@ -82,3 +88,10 @@ steps:
   - run:
       name: Fail CI in case tests failed
       command: exit ${TESTS_STATUS}
+
+  - when:
+      condition: << parameters.with_coverage >>
+      steps:
+        - run:
+            name: Fail CI in case minimum coverage failed
+            command: exit ${COVERAGE_STATUS}

--- a/src/scala/commands/test.yaml
+++ b/src/scala/commands/test.yaml
@@ -34,12 +34,26 @@ steps:
   - when:
       condition: << parameters.with_coverage >>
       steps:
-        - run: sbt coverage test:test
+        - run:
+            name: Try running tests with coverage
+            command: |
+              if sbt coverage test:test ; then
+                echo 'export TESTS_STATUS=0' >> $BASH_ENV
+              else
+                echo 'export TESTS_STATUS=1' >> $BASH_ENV
+              fi
         - run: SBT_OPTS="-Xmx<<parameters.memory_limit_for_heap>>" sbt coverageAggregate
   - unless:
       condition: << parameters.with_coverage >>
       steps:
-        - run: sbt test:test
+        - run:
+            name: Try tunning tests without coverage
+            command: |
+              if sbt test:test ; then
+                echo 'export TESTS_STATUS=0' >> $BASH_ENV
+              else
+                echo 'export TESTS_STATUS=1' >> $BASH_ENV
+              fi
   - when:
       condition: << parameters.with_coverage >>
       steps:
@@ -67,3 +81,7 @@ steps:
 
   - store_test_results:
       path: test-reports
+
+  - run:
+      name: Fail CI in case tests failed
+      command: exit ${TESTS_STATUS}

--- a/src/scala/commands/test.yaml
+++ b/src/scala/commands/test.yaml
@@ -33,27 +33,15 @@ steps:
         - run:
             name: Try running tests with coverage
             command: |
-              if sbt coverageOn +test coverageOff coverageAggregate
+              if sbt coverage test
               then
                 echo 'export TESTS_STATUS=0' >> $BASH_ENV
               else
                 echo 'export TESTS_STATUS=1' >> $BASH_ENV
               fi
-  - unless:
-      condition: << parameters.with_coverage >>
-      steps:
         - run:
-            name: Try running tests without coverage
-            command: |
-              if sbt +test
-              then
-                echo 'export TESTS_STATUS=0' >> $BASH_ENV
-              else
-                echo 'export TESTS_STATUS=1' >> $BASH_ENV
-              fi
-  - when:
-      condition: << parameters.with_coverage >>
-      steps:
+            name: Aggregate coverage reports
+            command: sbt coverageAggregate
         - code-climate/format_coverage:
             coverage_file: << parameters.project_base >>/<< parameters.path_to_coverage_file >>
             input_type: cobertura
@@ -69,9 +57,21 @@ steps:
         - run:
             name: Clean coverage results
             command: rm -rf coverage-reports
+  - unless:
+      condition: << parameters.with_coverage >>
+      steps:
+        - run:
+            name: Try running tests without coverage
+            command: |
+              if sbt test
+              then
+                echo 'export TESTS_STATUS=0' >> $BASH_ENV
+              else
+                echo 'export TESTS_STATUS=1' >> $BASH_ENV
+              fi
 
   - run:
-      name: Save test results
+      name: Find test reports
       command: |
         mkdir -p test-reports
         find . -type f -regex ".*/target/test-reports/.*xml" -exec cp {} test-reports/ \;

--- a/src/scala/commands/test.yaml
+++ b/src/scala/commands/test.yaml
@@ -37,19 +37,18 @@ steps:
         - run:
             name: Try running tests with coverage
             command: |
-              if sbt coverage test:test ; then
+              if SBT_OPTS="-Xmx<<parameters.memory_limit_for_heap>>" sbt coverageOn +test coverageOff coverageAggregate; then
                 echo 'export TESTS_STATUS=0' >> $BASH_ENV
               else
                 echo 'export TESTS_STATUS=1' >> $BASH_ENV
               fi
-        - run: SBT_OPTS="-Xmx<<parameters.memory_limit_for_heap>>" sbt coverageAggregate
   - unless:
       condition: << parameters.with_coverage >>
       steps:
         - run:
             name: Try tunning tests without coverage
             command: |
-              if sbt test:test ; then
+              if sbt test ; then
                 echo 'export TESTS_STATUS=0' >> $BASH_ENV
               else
                 echo 'export TESTS_STATUS=1' >> $BASH_ENV

--- a/src/scala/jobs/run_tests.yaml
+++ b/src/scala/jobs/run_tests.yaml
@@ -34,7 +34,12 @@ steps:
         - run: cc-test-reporter before-build
         - run:
             name: Check code coverage and run tests
-            command: sbt coverageOn +test coverageOff coverageAggregate
+            command: |
+              if sbt coverageOn +test coverageOff coverageAggregate; then
+                echo 'export TESTS_STATUS=0' >> $BASH_ENV
+              else
+                echo 'export TESTS_STATUS=1' >> $BASH_ENV
+              fi
 
         # To upload in code climate UI
         - run:
@@ -66,7 +71,12 @@ steps:
       steps:
         - run:
             name: Run tests
-            command: sbt +test
+            command: |
+              if sbt +test ; then
+                echo 'export TESTS_STATUS=0' >> $BASH_ENV
+              else
+                echo 'export TESTS_STATUS=1' >> $BASH_ENV
+              fi
 
   - run:
       name: Find test reports
@@ -80,6 +90,10 @@ steps:
   - run:
       name: Clean test reports
       command: rm -rf test-reports
+
+  - run:
+      name: Fail CI in case tests failed
+      command: exit ${TESTS_STATUS}
 
   - write_cache:
       cache_key: << parameters.cache_key >>

--- a/src/scala/jobs/run_tests.yaml
+++ b/src/scala/jobs/run_tests.yaml
@@ -35,12 +35,15 @@ steps:
         - run:
             name: Try running tests with coverage
             command: |
-              if sbt coverageOn +test coverageOff coverageAggregate
+              if sbt coverage +test
               then
                 echo 'export TESTS_STATUS=0' >> $BASH_ENV
               else
                 echo 'export TESTS_STATUS=1' >> $BASH_ENV
               fi
+        - run:
+            name: Aggregate coverage reports
+            command: sbt coverageAggregate
 
         # To upload in code climate UI
         - run:

--- a/src/scala/jobs/run_tests.yaml
+++ b/src/scala/jobs/run_tests.yaml
@@ -14,10 +14,6 @@ parameters:
     description: Whether to check code coverage with sbtcoverage
     type: boolean
     default: true
-  sbt_opts:
-    description: aggregating the test coverage requires more memory and stack size to be defined
-    type: string
-    default: "-Xmx1524M -Xms512m -Xss4m"
 
 executor: << parameters.executor >>
 
@@ -39,7 +35,6 @@ steps:
         - run:
             name: Try running tests with coverage
             command: |
-              export SBT_OPTS="<<parameters.sbt_opts>>"
               if sbt coverageOn +test coverageOff coverageAggregate
               then
                 echo 'export TESTS_STATUS=0' >> $BASH_ENV

--- a/src/scala/jobs/run_tests.yaml
+++ b/src/scala/jobs/run_tests.yaml
@@ -14,6 +14,10 @@ parameters:
     description: Whether to check code coverage with sbtcoverage
     type: boolean
     default: true
+  sbt_opts:
+    description: aggregating the test coverage requires more memory and stack size to be defined
+    type: string
+    default: "-Xmx1524M -Xms512m -Xss4m"
 
 executor: << parameters.executor >>
 
@@ -33,8 +37,9 @@ steps:
             version: 0.10.0
         - run: cc-test-reporter before-build
         - run:
-            name: Check code coverage and run tests
+            name: Try running tests with coverage
             command: |
+              export SBT_OPTS="<<parameters.sbt_opts>>"
               if sbt coverageOn +test coverageOff coverageAggregate
               then
                 echo 'export TESTS_STATUS=0' >> $BASH_ENV
@@ -71,7 +76,7 @@ steps:
       condition: << parameters.with_sbtcoverage >>
       steps:
         - run:
-            name: Run tests
+            name: Try running tests without coverage
             command: |
               if sbt +test
               then

--- a/src/scala/jobs/run_tests.yaml
+++ b/src/scala/jobs/run_tests.yaml
@@ -42,8 +42,14 @@ steps:
                 echo 'export TESTS_STATUS=1' >> $BASH_ENV
               fi
         - run:
-            name: Aggregate coverage reports
-            command: sbt coverageAggregate
+            name: Check for minimum coverage and aggregate coverage reports
+            command: |
+              if sbt coverageAggregate
+              then
+                echo 'export COVERAGE_STATUS=0' >> $BASH_ENV
+              else
+                echo 'export COVERAGE_STATUS=1' >> $BASH_ENV
+              fi
 
         # To upload in code climate UI
         - run:
@@ -99,6 +105,13 @@ steps:
   - run:
       name: Fail CI in case tests failed
       command: exit ${TESTS_STATUS}
+
+  - when:
+      condition: << parameters.with_sbtcoverage >>
+      steps:
+        - run:
+            name: Fail CI in case minimum coverage failed
+            command: exit ${COVERAGE_STATUS}
 
   - write_cache:
       cache_key: << parameters.cache_key >>

--- a/src/scala/jobs/run_tests.yaml
+++ b/src/scala/jobs/run_tests.yaml
@@ -35,7 +35,8 @@ steps:
         - run:
             name: Check code coverage and run tests
             command: |
-              if sbt coverageOn +test coverageOff coverageAggregate; then
+              if sbt coverageOn +test coverageOff coverageAggregate
+              then
                 echo 'export TESTS_STATUS=0' >> $BASH_ENV
               else
                 echo 'export TESTS_STATUS=1' >> $BASH_ENV
@@ -72,7 +73,8 @@ steps:
         - run:
             name: Run tests
             command: |
-              if sbt +test ; then
+              if sbt +test
+              then
                 echo 'export TESTS_STATUS=0' >> $BASH_ENV
               else
                 echo 'export TESTS_STATUS=1' >> $BASH_ENV

--- a/src/scala/jobs/test_and_compile.yaml
+++ b/src/scala/jobs/test_and_compile.yaml
@@ -25,10 +25,10 @@ parameters:
   submodule:
     description: sbt submodule to assembly. Leave empty for main module.
     type: string
-  memory_limit_for_heap:
-    description: aggregating the test coverage requires more memory to be defined
+  sbt_opts:
+    description: aggregating the test coverage requires more memory and stack size to be defined
     type: string
-    default: 1524M
+    default: "-Xmx1524M -Xms512m -Xss4m"
   skip_fat_jar_assembly:
     description: Whether to skip building fat-jar. Saves some time when the main sbt project is used as aggregator only.
     type: boolean
@@ -45,7 +45,7 @@ steps:
       project_base: << parameters.project_base >>
       with_coverage: << parameters.with_coverage >>
       path_to_coverage_file: << parameters.path_to_coverage_file >>
-      memory_limit_for_heap: << parameters.memory_limit_for_heap >>
+      sbt_opts: << parameters.sbt_opts >>
   - unless:
       condition: << parameters.skip_fat_jar_assembly >>
       steps:

--- a/src/scala/jobs/test_and_compile.yaml
+++ b/src/scala/jobs/test_and_compile.yaml
@@ -25,10 +25,6 @@ parameters:
   submodule:
     description: sbt submodule to assembly. Leave empty for main module.
     type: string
-  sbt_opts:
-    description: aggregating the test coverage requires more memory and stack size to be defined
-    type: string
-    default: "-Xmx1524M -Xms512m -Xss4m"
   skip_fat_jar_assembly:
     description: Whether to skip building fat-jar. Saves some time when the main sbt project is used as aggregator only.
     type: boolean
@@ -45,7 +41,6 @@ steps:
       project_base: << parameters.project_base >>
       with_coverage: << parameters.with_coverage >>
       path_to_coverage_file: << parameters.path_to_coverage_file >>
-      sbt_opts: << parameters.sbt_opts >>
   - unless:
       condition: << parameters.skip_fat_jar_assembly >>
       steps:


### PR DESCRIPTION
- remove `memory_limit_for_heap` and prefer usage of `.sbtopts` in the project root folder so that localhost and CI use the same settings
-  in case of a test failure, you get a better test report (works with CircleCI insights)
![Screenshot from 2021-04-07 08-37-17](https://user-images.githubusercontent.com/2332638/113824490-2b1f1f00-9780-11eb-85b5-67ad0f41a5b8.png)
- Coverage report can be always published (doesn't depend on the status of tests)
- In case tests or coverage checks fail, all reports will be published and after that, the CI will fail