### PR TITLE
Update scala executor with new jdk, scala, sbt versions

### DIFF
--- a/src/scala/executors/scala.yaml
+++ b/src/scala/executors/scala.yaml
@@ -4,7 +4,7 @@ parameters:
   version:
     description: jdk/sbt/scala version to use (docker tag)
     type: string
-    default: 8u265_1.4.3_2.13.3
+    default: 8u282_1.5.0_2.13.5
   resource_class:
     description: which circleci resource_class to use
     type: string

--- a/src/scala/jobs/publish.yaml
+++ b/src/scala/jobs/publish.yaml
@@ -29,7 +29,7 @@ steps:
 
         if [[ ! -z "$VERSION_TAG" ]]; then
           SNAPSHOT_VERSION=$(echo $VERSION_TAG|sed 's/-SNAPSHOT$//')-SNAPSHOT
-          VERSION_SBT_PATTERN="^ThisBuild / Version := \"$SNAPSHOT_VERSION\"$"
+          VERSION_SBT_PATTERN="^ThisBuild / version := \"$SNAPSHOT_VERSION\"$"
           if egrep "$VERSION_SBT_PATTERN" version.sbt; then
             echo "Publishing $VERSION_TAG ..."
             sbt 'set ThisBuild / version := "'"$VERSION_TAG"'"' +publish

--- a/src/scala/jobs/publish.yaml
+++ b/src/scala/jobs/publish.yaml
@@ -29,7 +29,7 @@ steps:
 
         if [[ ! -z "$VERSION_TAG" ]]; then
           SNAPSHOT_VERSION=$(echo $VERSION_TAG|sed 's/-SNAPSHOT$//')-SNAPSHOT
-          VERSION_SBT_PATTERN="^version in ThisBuild := \"$SNAPSHOT_VERSION\"$"
+          VERSION_SBT_PATTERN="^ThisBuild / Version := \"$SNAPSHOT_VERSION\"$"
           if egrep "$VERSION_SBT_PATTERN" version.sbt; then
             echo "Publishing $VERSION_TAG ..."
             sbt 'set ThisBuild / version := "'"$VERSION_TAG"'"' +publish


### PR DESCRIPTION
Don't forget to remove old 0.13 sbt syntax that has been deprecated in sbt 1.5.x in version.sbt checks

https://github.com/travelaudience/orbs/search?q=version+in+ThisBuild