### PR TITLE
Make more readable command deploy to staging

### DIFF
--- a/src/deploy/jobs/push_to_dag_cd_test_branch.yaml
+++ b/src/deploy/jobs/push_to_dag_cd_test_branch.yaml
@@ -35,6 +35,7 @@ executor: << parameters.executor >>
 steps:
   - run:
       # if a PR was opened on a branch, push to gitops repo's test branch ( deploy to staging ).
+      name: deploy-to-staging
       command: |
         if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
           git clone https://$<<parameters.github_token>>@$<<parameters.gitops_repo>>
@@ -48,7 +49,7 @@ steps:
             echo " create a new branch"
             git checkout -b "testbranch_<<parameters.dag_name>>_$<<parameters.version>>"
           fi
-          find "<<parameters.dag_name>>/" -name "*.ini" -exec sed -i -e "s/docker_tag\s*=\s*.*/docker_tag=$CIRCLE_SHA1/g" {} +
+          find "<<parameters.dag_name>>/" -name "*.ini" -exec sed -i -e "s/docker_tag\s*=\s*.*/docker_tag = $CIRCLE_SHA1/g" {} +
           git add .
           git commit --allow-empty -m "project:<<parameters.dag_name>> version:$<<parameters.version>>"
           GITHUB_TOKEN=$<<parameters.github_token>> git push --set-upstream origin "testbranch_<<parameters.dag_name>>_$<<parameters.version>>"


### PR DESCRIPTION
Add normal name instead of having full cmd rendered as a name:
![image](https://user-images.githubusercontent.com/2332638/116610200-8c787f00-a935-11eb-88e4-973563036d69.png)
