### PR TITLE
DEVOPS-1447 Helm 3 migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,9 @@ deploy_tag_filter: &deploy_tag_filter
   tags:
     only: /^[a-z,-]+-[0-9]+(\.[0-9]+){2}([0-9A-Za-z-+.]?)+/
 
-
 orbs:
-  cli: circleci/circleci-cli@0.1.2
-  orb-tools: circleci/orb-tools@9.1.0
+  cli: circleci/circleci-cli@0.1.9
+  orb-tools: circleci/orb-tools@10.0.3
 
 jobs:
   pre-orb-promotion-check:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Then create a release on Github with the new tag.
 
 Or, if you prefer you can just create the release on Github and it will automatically create a tag.
 
+## Local develpoment
+
+To validate orbs locally, feel free to use [CircleCI Local CLI](https://circleci.com/docs/2.0/local-cli/).
+
+```bash
+circleci orb validate <orb.yml>
+```
+
 ## Contributing
 
 Contributions are welcomed. However, these Orbs are used for travel audience CI process, and have been made in an opionated way. More information on how to contribute is in our guide: [Contributing Guide](CONTRIBUTING.md).

--- a/src/helm/commands/install.yaml
+++ b/src/helm/commands/install.yaml
@@ -13,11 +13,11 @@ parameters:
   kind_version:
     description: Version of Kind to be used
     type: string
-    default: "v0.5.1"
+    default: "v0.10.0"
   k8s_version:
     description: K8s version to be run with kind
     type: string
-    default: "v1.15.0"
+    default: "v1.17.0"
 steps:
   - run:
       command: |
@@ -28,15 +28,10 @@ steps:
           chmod +x kind
           mv kind /usr/local/bin/kind
           echo "Creating cluster..."
-          // TODO: docker executable is required for this to run. IE, needs a different executor type
           kind create cluster --name "chart-testing" --config .circleci/kind-config.yaml --image "kindest/node:<<parameters.k8s_version>>" --wait 60s
-
           echo $(kubectl get nodes)
           kubectl delete storageclass standard
           kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
-          kubectl --namespace kube-system create sa tiller
-          kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-          helm init --service-account tiller --upgrade --wait
           echo $(helm version)
 
           ct install

--- a/src/helm/commands/lint.yaml
+++ b/src/helm/commands/lint.yaml
@@ -18,12 +18,7 @@ steps:
       command: |
         set -e
 
-        # Hack to upgrade helm version
-        rm $(which helm)
-        curl -LO "https://kubernetes-helm.storage.googleapis.com/helm-v2.17.0-linux-amd64.tar.gz" && mkdir -p "/usr/local/helm-v2.17.0" && tar -xzf "helm-v2.17.0-linux-amd64.tar.gz" -C "/usr/local/helm-v2.17.0" && ln -s "/usr/local/helm-v2.17.0/linux-amd64/helm" /usr/local/bin/helm && rm -f "helm-v2.17.0-linux-amd64.tar.gz"
-
         if [ "$CT_CHART_REPOS" ]; then
-            helm init --client-only
             for i in $(echo $CT_CHART_REPOS | tr "," " ");
             do
                 repo_name=$(echo "$i" | cut -d'=' -f1)

--- a/src/helm/commands/package.yaml
+++ b/src/helm/commands/package.yaml
@@ -55,11 +55,6 @@ steps:
             echo "-----"
         }
 
-        # Hack to upgrade helm version
-        rm $(which helm)
-        curl -LO "https://kubernetes-helm.storage.googleapis.com/helm-v2.17.0-linux-amd64.tar.gz" && mkdir -p "/usr/local/helm-v2.17.0" && tar -xzf "helm-v2.17.0-linux-amd64.tar.gz" -C "/usr/local/helm-v2.17.0" && ln -s "/usr/local/helm-v2.17.0/linux-amd64/helm" /usr/local/bin/helm && rm -f "helm-v2.17.0-linux-amd64.tar.gz"
-
-        helm init --client-only  || true  # this step is required for helm v2
         helm version -c
         if [ "$CT_CHART_REPOS" ]; then
             for i in $(echo $CT_CHART_REPOS | tr "," " ");

--- a/src/helm/examples/package_and_push.yaml
+++ b/src/helm/examples/package_and_push.yaml
@@ -17,7 +17,7 @@ usage:
   version: 2.1
 
   orbs:
-    ta-helm: travelaudience/helm@0.1.0
+    ta-helm: travelaudience/helm@0.2.12
 
   workflows:
     build_and_test:

--- a/src/helm/executors/helm-tester.yaml
+++ b/src/helm/executors/helm-tester.yaml
@@ -1,3 +1,3 @@
 description: The docker container to used to test & build Helm charts. See https://github.com/helm/chart-testing
 docker:
-  - image: quay.io/helmpack/chart-testing:v2.4.0
+  - image: quay.io/helmpack/chart-testing:v3.3.1


### PR DESCRIPTION
**What this PR does / why we need it**:

**This is breaking change, removes commands necessary for Helm 2 to run. Changes work only with Helm 3.**

**Finally it will be minor version, which is not following semantic versioning. Why? -> It will enable us to roll this big change out without modification of any yaml files. Sorry for breaking changes for people using Helm 2.**

- Move orb setup from supporting version 2 to Helm 3
- Depreciate the Helm 2 support
- Set Helm version to `v3.5.4`
- Update dependencies for Helm
- Update CircleCI dependencies
- Update `kind`
- Remove `tiller`
- Update default Kubernetes version to `1.17`

**Special notes for your reviewer**:

**If applicable**:
- [x] All new Jobs, Commands, Executors, Parameters have descriptions
- [x] If PR adds a new feature, Examples have been added
- [x] README has been updated, if necessary
