### PR TITLE
Fix bug on gitops cd

### DIFF
--- a/src/deploy/commands/replace_image_tag.yaml
+++ b/src/deploy/commands/replace_image_tag.yaml
@@ -17,5 +17,5 @@ steps:
       command: |
         echo "Going to replace docker image tag with "<<parameters.docker_image_tag>>
         cd <<parameters.file_location>>
-        sed -i -e 's/image.tag\s*:\s*.*/image.tag: "'<<parameters.docker_image_tag>>'"/g' *
+        sed -i -e 's/tag\s*:\s*.*/tag: "'<<parameters.docker_image_tag>>'"/g' *
       name: Perform Replacements for docker image


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR fixes the issue with parsing of the `spec.values.image.tag`. The pervious sed depending on the yaml structure could not properly parse the tag.

Also it requires the following yaml structure:

```yaml
apiVersion: helm.toolkit.fluxcd.io/v2beta1
kind: HelmRelease
spec:
  ...
  values:
    image:
      tag: "TAG_GOES_HERE"
```

**Special notes for your reviewer**:

**If applicable**:
- [x] All new Jobs, Commands, Executors, Parameters have descriptions
- [x] If PR adds a new feature, Examples have been added
- [x] README has been updated, if necessary
